### PR TITLE
Enable excerpt and featured-media

### DIFF
--- a/asciidoc/kafka.adoc
+++ b/asciidoc/kafka.adoc
@@ -6,6 +6,8 @@
 :category: labs
 :tags: apache-kafka, events, extensions, procedures, data-stream
 :neo4j-versions: 3.5, 4.0
+:excerpt: Neo4j Streams integrates Neo4j with Apache Kafka event streams, to serve as a source of data, for instance change data (CDC) or a sink to ingest any kind of Kafka event into your graph.
+:featured-media: labs_beaker
 
 image::neo4j-loves-confluent.png[width=500]
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import com.neo4j.gradle.wordpress.WordPressUploadTask
 plugins {
     id 'org.asciidoctor.jvm.gems' version '3.2.0' apply false
     id 'org.asciidoctor.jvm.convert' version '3.2.0' apply false
-    id "com.neo4j.gradle.wordpress.WordPressPlugin" version "0.1.0"
+    id "com.neo4j.gradle.wordpress.WordPressPlugin" version "0.2.0"
 }
 
 apply plugin: 'org.asciidoctor.jvm.gems'
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    asciidoctorGems 'rubygems:neo4j-asciidoctor-extensions:0.0.5'
+    asciidoctorGems 'rubygems:neo4j-asciidoctor-extensions:0.1.1'
 }
 
 wordpress {
@@ -44,7 +44,7 @@ asciidoctorj {
             'icons': 'font',
             'stage': stage != null ? stage : '',
             'parent-path': '/labs',
-            'document-metadata-attrs-include': 'slug,parent-parent,tags*'
+            'document-metadata-attrs-include': 'slug,parent-path,excerpt,featured-media,tags*'
 }
 
 task convertHtml(type: AsciidoctorTask) {


### PR DESCRIPTION
And here's the result:

```json
[
    {
        "author": 99,
        "comment_status": "closed",
        "content": {
            "protected": false,
            "rendered": "....."
        },
        "date": "2020-05-22T01:57:00",
        "date_gmt": "2020-05-22T08:57:00",
        "excerpt": {
            "protected": false,
            "rendered": "<p>Neo4j Streams integrates Neo4j with Apache Kafka event streams, to serve as a source of data, for instance change data (CDC) or a sink to ingest any kind of Kafka event into your graph. Our Kafka Connect Plugin offers the… <a class=\"learn-more\" href=\"https://neo4j.com/labs/_testing_kafka/\">Read&nbsp;more&nbsp;&#8594;</a></p>\n"
        },
        "featured_media": 109441,
        "guid": {
            "rendered": "https://neo4j.com/labs/_testing_kafka/"
        },
        "id": 118139,
        "link": "https://neo4j.com/labs/_testing_kafka/",
        "menu_order": 0,
        "meta": [],
        "modified": "2020-05-22T01:57:05",
        "modified_gmt": "2020-05-22T08:57:05",
        "parent": 89063,
        "ping_status": "closed",
        "slug": "_testing_kafka",
        "status": "private",
        "template": "page-inner-100-blue.php",
        "title": {
            "rendered": "Private: Neo4j Streams Kafka Integration"
        },
        "type": "page"
    }
]
```

As far as I know, the excerpt is not visible when [editing the page from the WordPress dashboard](https://neo4j.com/wp-admin/post.php?post=118139&action=edit).
The featured media can be seen on the right column:

![featured-media](https://user-images.githubusercontent.com/333276/82651158-12675280-9c1c-11ea-8745-9e41b37d9688.png)


//cc @jexp 